### PR TITLE
Add relevant logging contexts only for the duration of the request

### DIFF
--- a/lib/logtail-rack/http_context.rb
+++ b/lib/logtail-rack/http_context.rb
@@ -18,8 +18,9 @@ module Logtail
             request_id: request.request_id
           )
 
-          CurrentContext.add(context.to_hash)
-          @app.call(env)
+          CurrentContext.with(context.to_hash) do
+            @app.call(env)
+          end
         end
       end
     end

--- a/lib/logtail-rack/user_context.rb
+++ b/lib/logtail-rack/user_context.rb
@@ -67,10 +67,12 @@ module Logtail
         def call(env)
           user_hash = get_user_hash(env)
           if user_hash
-            CurrentContext.add({user: user_hash})
+            CurrentContext.with({user: user_hash}) do
+              @app.call(env)
+            end
+          else
+            @app.call(env)
           end
-
-          @app.call(env)
         end
 
         private

--- a/lib/logtail-rack/version.rb
+++ b/lib/logtail-rack/version.rb
@@ -1,7 +1,7 @@
 module Logtail
   module Integrations
     module Rack
-      VERSION = "0.1.6"
+      VERSION = "0.2.0"
     end
   end
 end


### PR DESCRIPTION
This should prevent some contexts such us UserContext to be present on subsequent logs for requests without users