### PR TITLE
HTTPEvents: filter headers using `http_header_filters` configuration

### DIFF
--- a/spec/logtail-rack/http_events_spec.rb
+++ b/spec/logtail-rack/http_events_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+require "logtail-rack/config"
+require 'stringio'
+
+
+RSpec.describe Logtail::Integrations::Rack::HTTPEvents do
+  let(:app) { ->(env) { [200, env, "app"] } }
+  let(:mock_request) { Rack::MockRequest.env_for('https://example.com/test-page', { 'HTTP_AUTHORIZATION' => 'Bearer secret_token', 'HTTP_CONTENT_TYPE' => 'text/plain' }) }
+
+  let :middleware do
+    described_class.new(app)
+  end
+
+  it "log HTTP request and response" do
+    logs = capture_logs { middleware.call mock_request }
+
+    expect(logs.map { |log| log['message'] }).to match(['Started GET "/test-page"', /Completed 200 OK in \d+\.\d+ms/])
+  end
+
+  it "log HTTP request headers" do
+    logs = capture_logs { middleware.call mock_request }
+
+    request_headers_json = logs.first["event"]["http_request_received"]["headers_json"]
+    expect(JSON.parse(request_headers_json)).to eq({"Authorization" => "Bearer secret_token", "Content_Type" => "text/plain"})
+  end
+
+  it "filter HTTP request headers using http_header_filters" do
+    previous_http_header_filters = Logtail::Integrations::Rack::HTTPEvents.http_header_filters = %w[Authorization]
+    logs = capture_logs { middleware.call mock_request }
+
+    request_headers_json = logs.first["event"]["http_request_received"]["headers_json"]
+    expect(JSON.parse(request_headers_json)).to eq({"Authorization" => "[FILTERED]", "Content_Type" => "text/plain"})
+  ensure
+    Logtail::Integrations::Rack::HTTPEvents.http_header_filters = previous_http_header_filters
+  end
+
+  it "filter HTTP request headers using http_header_filters without regard to case or dashes" do
+    previous_http_header_filters = Logtail::Integrations::Rack::HTTPEvents.http_header_filters = %w[authorization CONTENT-TYPE]
+    logs = capture_logs { middleware.call mock_request }
+
+    request_headers_json = logs.first["event"]["http_request_received"]["headers_json"]
+    expect(JSON.parse(request_headers_json)).to eq({"Authorization" => "[FILTERED]", "Content_Type" => "[FILTERED]"})
+  ensure
+    Logtail::Integrations::Rack::HTTPEvents.http_header_filters = previous_http_header_filters
+  end
+
+  def capture_logs(&blk)
+    old_logger = Logtail::Config.instance.logger
+
+    string_io = StringIO.new
+    logger = Logtail::Logger.new(string_io)
+    logger.formatter = Logtail::Logger::JSONFormatter.new
+    Logtail::Config.instance.logger = logger
+
+    blk.call
+
+    string_io.string.split("\n").map { |record| JSON.parse(record) }
+  ensure
+    Logtail::Config.instance.logger = old_logger
+  end
+end


### PR DESCRIPTION
https://trello.com/c/sJMEewyz/2493-rails-integration-ruby-gem-httpheaderfilters-configuration-value-not-implemented

Implements HTTP configurable header filter:

```ruby
Logtail::Integrations::Rack::HTTPEvents.http_header_filters = ["Authorization"]
```

Matching headers will have their values replaced by `[FILTERED]`, similarly to https://github.com/logtail/logtail-ruby-rails/pull/15