### PR TITLE
Fix typo in HTTPContext middleware (request -> request.host)

### DIFF
--- a/lib/logtail-rack/http_context.rb
+++ b/lib/logtail-rack/http_context.rb
@@ -12,7 +12,7 @@ module Logtail
         def call(env)
           request = Util::Request.new(env)
           context = Contexts::HTTP.new(
-            host: Util::Encoding.force_utf8_encoding(request),
+            host: Util::Encoding.force_utf8_encoding(request.host),
             method: Util::Encoding.force_utf8_encoding(request.request_method),
             path: request.path,
             remote_addr: Util::Encoding.force_utf8_encoding(request.ip),

--- a/lib/logtail-rack/version.rb
+++ b/lib/logtail-rack/version.rb
@@ -1,7 +1,7 @@
 module Logtail
   module Integrations
     module Rack
-      VERSION = "0.2.3"
+      VERSION = "0.2.4"
     end
   end
 end


### PR DESCRIPTION
Fixes a typo made in #11. Fixes #12.