### PR TITLE
SH-1002 [CI] Update GitHub Actions versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: build
 
 on:
   push:
+    branches: [main]
+  pull_request:
   schedule:
     - cron: '20 5 * * 1'
   workflow_dispatch:
@@ -9,7 +11,7 @@ on:
 jobs:
   test:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,16 +26,21 @@ jobs:
           - "2.7"
           - "2.6"
           - "2.5"
-          - "2.4"
-          - "2.3"
-          - "jruby-9.4.3.0"
-          - "jruby-9.2.14.0"
-          - "truffleruby-23.0.0"
-          - "truffleruby-22.1.0"
+          - "truffleruby"
         rack-version:
           - "" # default Rack version
 
+        exclude:
+          # RubyGems on Ruby 2.5 ignores rack's required_ruby_version and
+          # installs a Rack that no longer runs on 2.5 — test it with a
+          # compatible Rack pinned below instead
+          - ruby-version: "2.5"
+            rack-version: ""
+
         include:
+          - ruby-version: "2.5"
+            rack-version: "~>2.2"
+
           - ruby-version: "2.7"
             rack-version: "~>1.2.0"
           - ruby-version: "2.7"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
             rack-version: "~>3.0.0"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
GitHub is deprecating Node.js 20 actions (forced to Node 24 since June 2nd, 2026; Node 20 removed from runners on September 16th, 2026), and Node 12/16 actions are already force-migrated. This bumps the affected actions to their latest majors (all Node 24):

- `actions/checkout` `v2` → `v7`

After the runner moved to ubuntu-24.04, the interpreter matrix was aligned with logtail-ruby: Ruby 2.3/2.4 and the pinned JRuby/TruffleRuby builds (unavailable on ubuntu-24.04) were dropped in favor of 2.5+ plus unpinned `truffleruby`. Ruby 2.5 now tests against Rack `~>2.2` — its RubyGems ignores rack's `required_ruby_version` and would otherwise install a Rack that no longer runs on 2.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

